### PR TITLE
Working directory fix for submodule update

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -665,9 +665,11 @@ function Start-PSBootstrap {
     try {
         # Update googletest submodule for linux native cmake
         if ($IsLinux -or $IsOSX) {
+            Push-Location $PSScriptRoot
             $Submodule = "$PSScriptRoot/src/libpsl-native/test/googletest"
             Remove-Item -Path $Submodule -Recurse -Force -ErrorAction SilentlyContinue
             git submodule update --init -- $submodule
+            Pop-Location
         }
 
         # Install ours and .NET's dependencies


### PR DESCRIPTION
The git submodule update for googletest must be run from the script's root directory. Otherwise, it will fail, causing tests not to compile.
